### PR TITLE
Disable browser UI tests in CI

### DIFF
--- a/ios/SealVault.xcodeproj/project.pbxproj
+++ b/ios/SealVault.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5850CE3EB5ADD54FD2A81B97 /* TransferForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5850C2CE182126E257B1DD22 /* TransferForm.swift */; };
 		5850CE62B626F0A8D83744FB /* TokenRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5850C6335A85D238AFAD5DC5 /* TokenRow.swift */; };
 		5850CFD0A5651186748412E7 /* AccountImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5850C4EEB3250EA90D094D1D /* AccountImage.swift */; };
+		6811E25928E2430B0044F9FE /* BrowserUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6811E25828E2430B0044F9FE /* BrowserUITest.swift */; };
 		68282DD328AD4B7D0034BFA4 /* WalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68282DD228AD4B7D0034BFA4 /* WalletView.swift */; };
 		685E445028B3B5E200BDFD5D /* SealVaultCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685E444E28B3B5E200BDFD5D /* SealVaultCore.swift */; };
 		686C1D052827C9DC00011311 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686C1D042827C9DC00011311 /* Config.swift */; };
@@ -37,7 +38,7 @@
 		68F6291228251A0900BDCD02 /* SealVaultApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F6291128251A0900BDCD02 /* SealVaultApp.swift */; };
 		68F6291628251A0B00BDCD02 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68F6291528251A0B00BDCD02 /* Assets.xcassets */; };
 		68F6291928251A0B00BDCD02 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68F6291828251A0B00BDCD02 /* Preview Assets.xcassets */; };
-		68F6292D28251A0B00BDCD02 /* SealVaultUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F6292C28251A0B00BDCD02 /* SealVaultUITests.swift */; };
+		68F6292D28251A0B00BDCD02 /* NativeUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F6292C28251A0B00BDCD02 /* NativeUITest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,9 @@
 		5850CC5D55BF9A269CEA1346 /* AddressMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressMenu.swift; sourceTree = "<group>"; };
 		5850CEC3F304338F5D6DC43D /* IconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		5850CFC23F4A51B23AA2A833 /* TokenLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenLabel.swift; sourceTree = "<group>"; };
+		6811E25828E2430B0044F9FE /* BrowserUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserUITest.swift; sourceTree = "<group>"; };
+		6811E25B28E243F30044F9FE /* FullTest.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FullTest.xctestplan; sourceTree = "<group>"; };
+		6811E25C28E2444C0044F9FE /* NativeUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = NativeUI.xctestplan; sourceTree = "<group>"; };
 		68282DD228AD4B7D0034BFA4 /* WalletView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletView.swift; sourceTree = "<group>"; };
 		685E444E28B3B5E200BDFD5D /* SealVaultCore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SealVaultCore.swift; path = Generated/SealVaultCore.swift; sourceTree = "<group>"; };
 		686C1D042827C9DC00011311 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
@@ -83,7 +87,7 @@
 		68F6291528251A0B00BDCD02 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		68F6291828251A0B00BDCD02 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		68F6292828251A0B00BDCD02 /* SealVaultUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SealVaultUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		68F6292C28251A0B00BDCD02 /* SealVaultUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SealVaultUITests.swift; sourceTree = "<group>"; };
+		68F6292C28251A0B00BDCD02 /* NativeUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeUITest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +109,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6811E25A28E243D40044F9FE /* TestPlans */ = {
+			isa = PBXGroup;
+			children = (
+				6811E25B28E243F30044F9FE /* FullTest.xctestplan */,
+				6811E25C28E2444C0044F9FE /* NativeUI.xctestplan */,
+			);
+			path = TestPlans;
+			sourceTree = "<group>";
+		};
 		681D2A58283195BC000DBC93 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -136,6 +149,7 @@
 		68F6290528251A0900BDCD02 = {
 			isa = PBXGroup;
 			children = (
+				6811E25A28E243D40044F9FE /* TestPlans */,
 				68F6291028251A0900BDCD02 /* SealVaultApp */,
 				68F6292B28251A0B00BDCD02 /* SealVaultUITests */,
 				68F6290F28251A0900BDCD02 /* Products */,
@@ -195,7 +209,8 @@
 		68F6292B28251A0B00BDCD02 /* SealVaultUITests */ = {
 			isa = PBXGroup;
 			children = (
-				68F6292C28251A0B00BDCD02 /* SealVaultUITests.swift */,
+				68F6292C28251A0B00BDCD02 /* NativeUITest.swift */,
+				6811E25828E2430B0044F9FE /* BrowserUITest.swift */,
 			);
 			path = SealVaultUITests;
 			sourceTree = "<group>";
@@ -345,7 +360,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				68F6292D28251A0B00BDCD02 /* SealVaultUITests.swift in Sources */,
+				6811E25928E2430B0044F9FE /* BrowserUITest.swift in Sources */,
+				68F6292D28251A0B00BDCD02 /* NativeUITest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/SealVault.xcodeproj/xcshareddata/xcschemes/SealVault.xcscheme
+++ b/ios/SealVault.xcodeproj/xcshareddata/xcschemes/SealVault.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1330"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:TestPlans/FullTest.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/NativeUI.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ios/SealVaultUITests/BrowserUITest.swift
+++ b/ios/SealVaultUITests/BrowserUITest.swift
@@ -6,15 +6,8 @@
 
 import XCTest
 
-class SealVaultUITests: XCTestCase {
-    var timeOutSeconds: TimeInterval {
-        if ProcessInfo.processInfo.environment["CI"] == "true" {
-            return 120
-        } else {
-            return 30
-        }
-    }
-    let minAccounts = 1
+final class BrowserUITest: XCTestCase {
+    var timeOutSeconds: TimeInterval = 30
     let ethereumTestUrl = "http://localhost:8080/ethereum.html"
     let newTabTestUrl = "http://localhost:8080/open-new-tab.html"
     let browserAddressBar = "browserAddressBar"
@@ -67,55 +60,6 @@ class SealVaultUITests: XCTestCase {
         let finishedOk = app.webViews.staticTexts["Example Domain"]
         XCTAssert(finishedOk.waitForExistence(timeout: timeOutSeconds))
     }
-
-    func testAccountList() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        let accountsButton = app.tabBars.buttons["Accounts"]
-        _ = accountsButton.waitForExistence(timeout: timeOutSeconds)
-        accountsButton.tap()
-
-        let rowCount = app.collectionViews.element(boundBy: 0).cells.count
-        XCTAssert(rowCount >= minAccounts)
-    }
-
-//    func testAccountSearch() throws {
-//        // UI tests must launch the application that they test.
-//        let app = XCUIApplication()
-//        app.launch()
-//        app.tabBars.buttons["Accounts"].tap()
-//
-//        let cells = app.tables.element(boundBy: 0).cells
-//        let rowCount = cells.count
-//
-//        // Drag down first row to display search bar
-//        let firstRow = cells.element(boundBy: 0)
-//        let start = firstRow.coordinate(withNormalizedOffset: CGVector(dx: 10, dy: 0))
-//        let finish = firstRow.coordinate(withNormalizedOffset: CGVector(dx: 10, dy: 10))
-//        start.press(forDuration: 0.01, thenDragTo: finish)
-//
-//        let searchField = app.searchFields.element(boundBy: 0)
-//
-//        // Type into the search bar
-//        searchField.tap()
-//        app.typeText("De")
-//
-//        // TODO: add this back after we can create account
-//        // Make sure filtering works (fewer rows are displayed after typing than originally)
-//        // XCTAssert(rowCount > cells.count)
-//
-//        // Accept first autocomplete suggestion
-//        cells.element(boundBy: 0).tap()
-//
-//        // Open account view
-//        cells.element(boundBy: 0).tap()
-//
-//        // Check that account view was opened by existence of back button to accounts overview
-//        let firstNavBarButtonLabel = app.navigationBars.buttons.element(boundBy: 0).label
-//        XCTAssert(firstNavBarButtonLabel == "Accounts")
-//    }
 }
 
 func startBrowserApp() throws -> XCUIApplication {

--- a/ios/SealVaultUITests/NativeUITest.swift
+++ b/ios/SealVaultUITests/NativeUITest.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+final class NativeUITest: XCTestCase {
+    func testAccountList() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        let accountsButton = app.tabBars.buttons["Accounts"]
+        _ = accountsButton.waitForExistence(timeout: 5)
+        accountsButton.tap()
+
+        let rowCount = app.collectionViews.element(boundBy: 0).cells.count
+        XCTAssert(rowCount >= 1)
+    }
+
+//    func testAccountSearch() throws {
+//        // UI tests must launch the application that they test.
+//        let app = XCUIApplication()
+//        app.launch()
+//        app.tabBars.buttons["Accounts"].tap()
+//
+//        let cells = app.tables.element(boundBy: 0).cells
+//        let rowCount = cells.count
+//
+//        // Drag down first row to display search bar
+//        let firstRow = cells.element(boundBy: 0)
+//        let start = firstRow.coordinate(withNormalizedOffset: CGVector(dx: 10, dy: 0))
+//        let finish = firstRow.coordinate(withNormalizedOffset: CGVector(dx: 10, dy: 10))
+//        start.press(forDuration: 0.01, thenDragTo: finish)
+//
+//        let searchField = app.searchFields.element(boundBy: 0)
+//
+//        // Type into the search bar
+//        searchField.tap()
+//        app.typeText("De")
+//
+//        // TODO: add this back after we can create account
+//        // Make sure filtering works (fewer rows are displayed after typing than originally)
+//        // XCTAssert(rowCount > cells.count)
+//
+//        // Accept first autocomplete suggestion
+//        cells.element(boundBy: 0).tap()
+//
+//        // Open account view
+//        cells.element(boundBy: 0).tap()
+//
+//        // Check that account view was opened by existence of back button to accounts overview
+//        let firstNavBarButtonLabel = app.navigationBars.buttons.element(boundBy: 0).label
+//        XCTAssert(firstNavBarButtonLabel == "Accounts")
+//    }
+}

--- a/ios/TestPlans/FullTest.xctestplan
+++ b/ios/TestPlans/FullTest.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "0858435D-7F9E-45C4-96F9-99411DA05B54",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:SealVault.xcodeproj",
+        "identifier" : "68F6292728251A0B00BDCD02",
+        "name" : "SealVaultUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/ios/TestPlans/NativeUI.xctestplan
+++ b/ios/TestPlans/NativeUI.xctestplan
@@ -1,0 +1,27 @@
+{
+  "configurations" : [
+    {
+      "id" : "675D3FE9-CE06-400E-B644-390AAC324745",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "BrowserUITest"
+      ],
+      "target" : {
+        "containerPath" : "container:SealVault.xcodeproj",
+        "identifier" : "68F6292728251A0B00BDCD02",
+        "name" : "SealVaultUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -43,6 +43,8 @@ platform :ios do
     lint()
     reset_simulator_contents()
     pre_build()
-    run_tests(scheme: "SealVault", devices: ["iPhone 13"], clean: true)
+    # Browser tests are flaky in CI
+    testplan = ENV["CI"] ? "NativeUI" : "FullTest"
+    run_tests(scheme: "SealVault", devices: ["iPhone 13"], clean: true, testplan: testplan)
   end
 end


### PR DESCRIPTION
UI tests involving the built in browser in iOS are flaky.  UI elements randomly don't appear. Trying to increase timeouts doesn't help. This change disables browser UI tests and runs only native UI tests in CI.