### PR TITLE
Refactor in-page provider to async for performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4149,6 +4149,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "ethers-core 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "sealvault_core",
  "tokio",
 ]

--- a/ci.py
+++ b/ci.py
@@ -71,9 +71,7 @@ def run_clippy(target=None):
     # The first two rules are disabled to regressions in clippy that produce false positives:
     # https://github.com/rust-lang/rust-clippy/issues/8867
     # https://github.com/rust-lang/rust-clippy/issues/9014
-    # The third rule is allowed, because there is some generated code that spits out camel case despite our best
-    # efforts. Please don't use non-snake case variable names though!
-    allow = "-A clippy::derive_partial_eq_without_eq -A clippy::extra_unused_lifetimes -A non_snake_case"
+    allow = "-A clippy::derive_partial_eq_without_eq -A clippy::extra_unused_lifetimes"
 
     sp.run(
         f"cargo clippy {target_arg}-- -D warnings {allow}".split(" "),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = { version = "1.0.81", features = ["alloc"] }
 strum = { version = "0.24.1", features = ["derive", "strum_macros"] }
 strum_macros = "^0.24"
 thiserror = "1.0.31"
-tokio = "1.18.2"
+tokio = "1.21.2"
 typed-builder = "0.10.0"
 uniffi = "0.20.0"
 uniffi_macros = "0.20.0"

--- a/core/src/SealVaultCore.udl
+++ b/core/src/SealVaultCore.udl
@@ -26,7 +26,7 @@ interface AppCore {
     string get_in_page_script(string rpc_provider_name, string request_handler_name);
 
     [Throws=CoreError]
-    string in_page_request(InPageRequestContextI context, string raw_request);
+    void in_page_request(InPageRequestContextI context, string raw_request);
 
     [Throws=CoreError]
     string eth_transfer_native_token(string from_address_id, string to_checksum_address, string amount);
@@ -104,8 +104,8 @@ dictionary DappApprovalParams {
 };
 
 callback interface CoreInPageCallbackI {
-    // TODO arguments cannot be snake case due to uniffi-rs bug
-    boolean approve_dapp(DappApprovalParams dappApproval);
-    void notify(string messageHex);
+    boolean approve_dapp(DappApprovalParams dapp_approval);
+    void respond(string response_hex);
+    void notify(string message_hex);
 };
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -10,6 +10,7 @@ pub const DB_CONNECTION_POOL_SIZE: u32 = 4;
 pub const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(1);
 pub const TOKIO_WORKER_THREADS: usize = 1;
 pub const TOKIO_MAX_BLOCKING_THREADS: usize = 8;
+pub const MAX_ASYNC_CONCURRENT_REQUESTS: usize = 8;
 
 // User
 pub const DEFAULT_ACCOUNT_NAME: &str = "Default";
@@ -31,7 +32,8 @@ pub const PROFILE_PIC_EXTENSION: &str = ".jpeg";
 pub const RPC_PROVIDER_PLACEHOLDER: &str = "<SEALVAULT_RPC_PROVIDER>";
 pub const REQUEST_HANDLER_PLACEHOLDER: &str = "<SEALVAULT_REQUEST_HANDLER>";
 pub const DEFAULT_CHAIN_ID_PLACEHOLDER: &str = "<SEALVAULT_DEFAULT_CHAIN_ID>";
-pub const DEFAULT_NETWORK_VERSION_PLACEHOLDER: &str = "<SEALVAULT_DEFAULT_NETWORK_VERSION>";
+pub const DEFAULT_NETWORK_VERSION_PLACEHOLDER: &str =
+    "<SEALVAULT_DEFAULT_NETWORK_VERSION>";
 pub const ETH_NATIVE_TOKEN_PREFIX: &str = "protocols/eth/native-tokens";
 pub const NATIVE_TOKEN_EXTENSION: &str = ".png";
 pub const FALLBACK_FAVICON_ASSET: &str = "fallback-favicon.png";

--- a/core/src/db/models/address.rs
+++ b/core/src/db/models/address.rs
@@ -186,10 +186,7 @@ impl Address {
     }
 
     /// Fetch the the address entity by id.
-    pub fn fetch(
-        conn: &mut SqliteConnection,
-        address_id: &str,
-    ) -> Result<Self, Error> {
+    pub fn fetch(conn: &mut SqliteConnection, address_id: &str) -> Result<Self, Error> {
         use addresses::dsl as a;
 
         let address: Self = addresses::table

--- a/core/src/db/models/dapp.rs
+++ b/core/src/db/models/dapp.rs
@@ -191,5 +191,4 @@ mod tests {
         let identifier = Dapp::dapp_identifier(url, &psl).unwrap();
         assert_eq!(identifier, "example.com");
     }
-
 }

--- a/core/src/db/models/mod.rs
+++ b/core/src/db/models/mod.rs
@@ -22,8 +22,6 @@ pub use chain::{Chain, EthChain};
 pub use dapp::Dapp;
 pub use data_encryption_key::{DataEncryptionKey, NewDataEncryptionKey};
 pub use data_migration::{DataMigration, NewDataMigration};
-pub use local_dapp_session::{
-    DappSessionParams, LocalDappSession,
-};
+pub use local_dapp_session::{DappSessionParams, LocalDappSession};
 pub use local_encrypted_dek::{LocalEncryptedDek, NewLocalEncryptedDek};
 pub use local_settings::LocalSettings;

--- a/core/src/dto.rs
+++ b/core/src/dto.rs
@@ -5,14 +5,16 @@
 use crate::async_runtime as rt;
 use crate::db::models::ListAddressesForDappParams;
 /// Data transfer objects passed through FFI to host languages.
-use crate::db::{models as m, DeferredTxConnection};
+use crate::db::{models as m, ConnectionPool, DeferredTxConnection};
 use crate::favicon::fetch_favicons;
-use crate::http_client::{GetAllBytes, HttpClient, HttpClientError};
+use crate::http_client::HttpClient;
 use crate::protocols::eth::ankr;
 use crate::protocols::{eth, TokenType};
 use crate::Error;
-use std::collections::HashMap;
+
+use crate::app_core::CoreResources;
 use std::iter;
+use std::sync::Arc;
 use typed_builder::TypedBuilder;
 use url::Url;
 
@@ -45,7 +47,7 @@ pub struct CoreAddress {
     pub blockchain_explorer_link: String,
     pub chain_display_name: String,
     pub chain_icon: Vec<u8>,
-    pub native_token: CoreToken
+    pub native_token: CoreToken,
 }
 
 #[derive(Clone, Debug, TypedBuilder)]
@@ -87,92 +89,96 @@ impl From<Error> for CoreError {
 }
 
 #[derive(Debug)]
-pub struct Assembler<'a> {
-    eth_chains_by_db_id: HashMap<String, m::EthChain>,
-    http_client: &'a HttpClient,
-    rpc_manager: &'a dyn eth::RpcManagerI,
-    // TODO avoid blocking with open db connection
-    tx_conn: DeferredTxConnection<'a>,
+pub struct Assembler {
+    resources: Arc<CoreResources>,
 }
 
-impl<'a> Assembler<'a> {
-    pub fn init(
-        http_client: &'a HttpClient,
-        rpc_manager: &'a dyn eth::RpcManagerI,
-        mut tx_conn: DeferredTxConnection<'a>,
-    ) -> Result<Self, Error> {
-        let eth_chains = m::Chain::list_eth_chains(tx_conn.as_mut())?;
-        let eth_chains_by_db_id: HashMap<String, m::EthChain> = eth_chains
-            .into_iter()
-            .map(|c| (c.db_id.clone(), c))
-            .collect();
+impl Assembler {
+    pub fn new(resources: Arc<CoreResources>) -> Self {
+        Self { resources }
+    }
 
-        Ok(Self {
-            eth_chains_by_db_id,
-            http_client,
-            rpc_manager,
-            tx_conn,
-        })
+    fn connection_pool(&self) -> &ConnectionPool {
+        &self.resources.connection_pool
+    }
+
+    fn http_client(&self) -> &HttpClient {
+        &self.resources.http_client
+    }
+
+    fn rpc_manager(&self) -> &dyn eth::RpcManagerI {
+        &*self.resources.rpc_manager
     }
 
     /// Combine data from multiple sources to create Account data transfer objects.
-    pub fn assemble_accounts(&mut self) -> Result<Vec<CoreAccount>, Error> {
-        let mut accounts: Vec<CoreAccount> = Default::default();
-        for account in m::Account::list_all(self.tx_conn.as_mut())? {
-            let m::Account {
-                deterministic_id,
-                name,
-                picture_id,
-                created_at,
-                updated_at,
-                ..
-            } = account;
+    pub fn assemble_accounts(&self) -> Result<Vec<CoreAccount>, Error> {
+        // Important to pass down connection to make sure we see a consistent view of the db.
+        self.connection_pool().deferred_transaction(|mut tx_conn| {
+            let mut accounts: Vec<CoreAccount> = Default::default();
+            for account in m::Account::list_all(tx_conn.as_mut())? {
+                let m::Account {
+                    deterministic_id,
+                    name,
+                    picture_id,
+                    created_at,
+                    updated_at,
+                    ..
+                } = account;
 
-            let dapps = self.assemble_dapps(&deterministic_id)?;
-            let wallets = self.assemble_wallets(&deterministic_id)?;
-            let picture =
-                m::AccountPicture::fetch_image(self.tx_conn.as_mut(), &picture_id)?;
+                let dapps = self.assemble_dapps(&mut tx_conn, &deterministic_id)?;
+                let wallets = self.assemble_wallets(&mut tx_conn, &deterministic_id)?;
+                let picture =
+                    m::AccountPicture::fetch_image(tx_conn.as_mut(), &picture_id)?;
 
-            let account = CoreAccount::builder()
-                .id(deterministic_id)
-                .name(name)
-                .picture(picture)
-                .wallets(wallets)
-                .dapps(dapps)
-                .created_at(created_at)
-                .updated_at(updated_at)
-                .build();
+                let account = CoreAccount::builder()
+                    .id(deterministic_id)
+                    .name(name)
+                    .picture(picture)
+                    .wallets(wallets)
+                    .dapps(dapps)
+                    .created_at(created_at)
+                    .updated_at(updated_at)
+                    .build();
 
-            accounts.push(account);
-        }
-        Ok(accounts)
+                accounts.push(account);
+            }
+            Ok(accounts)
+        })
     }
 
-    fn assemble_wallets(&mut self, account_id: &str) -> Result<Vec<CoreAddress>, Error> {
-        let addresses =
-            m::Address::list_account_wallets(self.tx_conn.as_mut(), account_id)?;
+    fn assemble_wallets(
+        &self,
+        tx_conn: &mut DeferredTxConnection,
+        account_id: &str,
+    ) -> Result<Vec<CoreAddress>, Error> {
+        let addresses = m::Address::list_account_wallets(tx_conn.as_mut(), account_id)?;
         let mut results: Vec<CoreAddress> = Default::default();
         for address in addresses {
-            let address = self.assemble_address(address, true)?;
+            let address = self.assemble_address(tx_conn, address, true)?;
             results.push(address);
         }
         Ok(results)
     }
 
-    fn assemble_dapps(&mut self, account_id: &str) -> Result<Vec<CoreDapp>, Error> {
-        let dapps = m::Dapp::list_for_account(self.tx_conn.as_mut(), account_id)?;
+    fn assemble_dapps(
+        &self,
+        tx_conn: &mut DeferredTxConnection,
+        account_id: &str,
+    ) -> Result<Vec<CoreDapp>, Error> {
+        let dapps = m::Dapp::list_for_account(tx_conn.as_mut(), account_id)?;
         let urls: Vec<Url> = dapps.iter().map(|d| d.url.clone().into()).collect();
-        let favicons = fetch_favicons(self.http_client, urls)?;
+        let favicons = fetch_favicons(self.http_client(), urls)?;
         let mut results: Vec<CoreDapp> = Default::default();
         for (dapp, icon) in dapps.into_iter().zip(favicons) {
-            let dapp = self.assemble_dapp(account_id, dapp, icon)?;
+            let dapp = self.assemble_dapp(tx_conn, account_id, dapp, icon)?;
             results.push(dapp);
         }
         Ok(results)
     }
 
     fn assemble_dapp(
-        &mut self,
+        &self,
+        tx_conn: &mut DeferredTxConnection,
         account_id: &str,
         dapp: m::Dapp,
         favicon: Option<Vec<u8>>,
@@ -182,8 +188,8 @@ impl<'a> Assembler<'a> {
             .dapp_id(&dapp.deterministic_id)
             .build();
         let mut addresses: Vec<CoreAddress> = Default::default();
-        for address in m::Address::list_for_dapp(self.tx_conn.as_mut(), &params)? {
-            let address = self.assemble_address(address, false)?;
+        for address in m::Address::list_for_dapp(tx_conn.as_mut(), &params)? {
+            let address = self.assemble_address(tx_conn, address, false)?;
             addresses.push(address)
         }
         let m::Dapp {
@@ -204,22 +210,22 @@ impl<'a> Assembler<'a> {
         Ok(result)
     }
 
-    fn chain_id_for_address(&self, address: &m::Address) -> Result<eth::ChainId, Error> {
-        let chain = self
-            .eth_chains_by_db_id
-            .get(&*address.chain_id)
-            .ok_or(Error::Fatal {
-                error: format!("Unknown chain db id: {}", &*address.chain_id),
-            })?;
-        Ok(chain.chain_id)
+    fn chain_id_for_address(
+        &self,
+        tx_conn: &mut DeferredTxConnection,
+        address: &m::Address,
+    ) -> Result<eth::ChainId, Error> {
+        let chain_id = m::Chain::fetch_eth_chain_id(tx_conn.as_mut(), &address.chain_id)?;
+        Ok(chain_id)
     }
 
     fn assemble_address(
         &self,
+        tx_conn: &mut DeferredTxConnection,
         address: m::Address,
         is_wallet: bool,
     ) -> Result<CoreAddress, Error> {
-        let chain_id = self.chain_id_for_address(&address)?;
+        let chain_id = self.chain_id_for_address(tx_conn, &address)?;
 
         let m::Address {
             deterministic_id,
@@ -247,14 +253,30 @@ impl<'a> Assembler<'a> {
         Ok(result)
     }
 
-    pub fn native_token_for_address(&mut self, address_id: &str) -> Result<CoreToken, Error> {
-        let address = m::Address::fetch(self.tx_conn.as_mut(), address_id)?;
-        let chain_id = self.chain_id_for_address(&address)?;
+    fn fetch_token_address(
+        &self,
+        address_id: &str,
+    ) -> Result<(eth::ChainId, m::Address), Error> {
+        self.resources
+            .connection_pool
+            .deferred_transaction(|mut tx_conn| {
+                let address = m::Address::fetch(tx_conn.as_mut(), address_id)?;
+                let chain_id = self.chain_id_for_address(&mut tx_conn, &address)?;
+                Ok((chain_id, address))
+            })
+    }
+
+    pub fn native_token_for_address(&self, address_id: &str) -> Result<CoreToken, Error> {
+        let (chain_id, address) = self.fetch_token_address(address_id)?;
         self.assemble_native_token(&address.address, chain_id)
     }
 
-    fn native_token_without_balance(&self, address: &str, chain_id: eth::ChainId) -> Result<CoreToken, Error> {
-        let native_token_id = format!("eth-{}-{}", chain_id,  address);
+    fn native_token_without_balance(
+        &self,
+        address: &str,
+        chain_id: eth::ChainId,
+    ) -> Result<CoreToken, Error> {
+        let native_token_id = format!("eth-{}-{}", chain_id, address);
         let icon = Some(chain_id.native_token().icon()?);
         let native_token = CoreToken::builder()
             .id(native_token_id)
@@ -272,15 +294,17 @@ impl<'a> Assembler<'a> {
         chain_id: eth::ChainId,
     ) -> Result<CoreToken, Error> {
         let mut native_token = self.native_token_without_balance(address, chain_id)?;
-        let provider = self.rpc_manager.eth_api_provider(chain_id);
+        let provider = self.rpc_manager().eth_api_provider(chain_id);
         let balance = provider.native_token_balance(address)?;
         native_token.amount = Some(balance.display_amount());
         Ok(native_token)
     }
 
-    pub fn fungible_tokens_for_address(&mut self, address_id: &str) -> Result<Vec<CoreToken>, Error> {
-        let address = m::Address::fetch(self.tx_conn.as_mut(), address_id)?;
-        let chain_id = self.chain_id_for_address(&address)?;
+    pub fn fungible_tokens_for_address(
+        &self,
+        address_id: &str,
+    ) -> Result<Vec<CoreToken>, Error> {
+        let (chain_id, address) = self.fetch_token_address(address_id)?;
         self.assemble_fungible_tokens(&address.address, chain_id)
     }
 
@@ -315,24 +339,7 @@ impl<'a> Assembler<'a> {
         let logo_urls = tokens_with_logo
             .iter()
             .map(|token| token.logo.clone().expect("tokens with logo have logo"));
-        let icons = self.http_client.get_bytes(logo_urls)?;
-        let mut maybe_icons: Vec<Option<Vec<u8>>> =
-            Vec::with_capacity(tokens_with_logo.len());
-        for icon_res in icons {
-            match icon_res {
-                Ok(icon) => maybe_icons.push(Some(icon)),
-                Err(HttpClientError::Request { error }) => {
-                    // Icon request errors are not sensitive, ok to log.
-                    log::error!("Failed to fetch icon for fungible token with request error: {:?}", error);
-                    maybe_icons.push(None);
-                }
-                Err(HttpClientError::Middleware { error }) => {
-                    log::error!("Failed to fetch icon for fungible token with middleware error: {:?}", error);
-                    maybe_icons.push(None);
-                }
-                Err(HttpClientError::Core { error }) => Err(error)?,
-            }
-        }
+        let maybe_icons = rt::block_on(self.http_client().get_bytes(logo_urls));
         let icons_for_all = maybe_icons
             .into_iter()
             .chain(iter::repeat(None).take(tokens_no_logo.len()));

--- a/core/src/encryption/keychains/ios_keychain.rs
+++ b/core/src/encryption/keychains/ios_keychain.rs
@@ -133,11 +133,7 @@ impl IOSKeychainInternal {
         };
     }
 
-    fn put(
-        &self,
-        key: KeyEncryptionKey,
-        class: KeychainStorage,
-    ) -> Result<(), Error> {
+    fn put(&self, key: KeyEncryptionKey, class: KeychainStorage) -> Result<(), Error> {
         let (name, key_material) = key.into_keychain();
         let wrapped_value = Arc::new(key_material);
         let query = class.put_query(&name, wrapped_value);

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -54,7 +54,10 @@ impl From<diesel::result::Error> for Error {
                 } else {
                     Error::Fatal {
                         // Don't include `DatabaseErrorInformation` as it can contain user data.
-                        error: format!("Unexpected Diesel database error kind: '{:?}'", kind),
+                        error: format!(
+                            "Unexpected Diesel database error kind: '{:?}'",
+                            kind
+                        ),
                     }
                 }
             }
@@ -153,7 +156,7 @@ impl From<url::ParseError> for Error {
     fn from(err: url::ParseError) -> Self {
         Error::Retriable {
             // Error is opaque, OK to expose.
-            error: err.to_string()
+            error: err.to_string(),
         }
     }
 }

--- a/core/src/favicon.rs
+++ b/core/src/favicon.rs
@@ -2,37 +2,44 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::http_client::{GetAllBytes, HttpClientError};
+use crate::async_runtime as rt;
+use crate::http_client::HttpClient;
 use crate::{config, Error};
-
+use std::iter;
 use url::{Host, Url};
 
 /// Fetch favicons for a list of urls concurrently from the DuckDuckGo favicon api.
-/// Uses local cache.
-/// Returns the favicons as png, or a fallback if failed to fetch.
-pub fn fetch_favicons(
-    client: &impl GetAllBytes,
+/// Uses local cache and returns None if there was an error fetching the favicon.
+pub async fn fetch_favicons_async(
+    client: &HttpClient,
     urls: impl IntoIterator<Item = Url>,
 ) -> Result<Vec<Option<Vec<u8>>>, Error> {
     let mut api_urls: Vec<Url> = Default::default();
     for url in urls {
         api_urls.push(site_url_to_api_url(url)?);
     }
-    let responses = client.get_bytes(api_urls.into_iter())?;
-    let mut result: Vec<Option<Vec<u8>>> = Default::default();
-    for response in responses {
-        let favicon: Option<Vec<u8>> = match response {
-            Ok(favicon) => Some(favicon),
-            Err(HttpClientError::Core { error }) => {
-                // Propagate core error
-                Err(error)?
-            }
-            // In case of middleware or reqwuest error, fetch fallback.
-            _error => None,
-        };
-        result.push(favicon)
-    }
-    Ok(result)
+    let results = client.get_bytes(api_urls.into_iter()).await;
+    Ok(results)
+}
+
+/// Fetch favicons for a list of urls concurrently from the DuckDuckGo favicon api.
+/// Uses local cache and returns None if there was an error fetching the favicon.
+pub fn fetch_favicons(
+    client: &HttpClient,
+    urls: impl IntoIterator<Item = Url>,
+) -> Result<Vec<Option<Vec<u8>>>, Error> {
+    rt::block_on(fetch_favicons_async(client, urls))
+}
+
+/// Fetch one favicon from the DuckDuckGo favicon api.
+/// Uses local cache and returns None if there was an error fetching the favicon.
+pub async fn fetch_favicon_async(
+    client: &HttpClient,
+    url: Url,
+) -> Result<Option<Vec<u8>>, Error> {
+    let results = fetch_favicons_async(client, iter::once(url)).await?;
+    let first = results.into_iter().next().flatten();
+    Ok(first)
 }
 
 fn site_url_to_api_url(url: Url) -> Result<Url, Error> {
@@ -52,49 +59,7 @@ fn site_url_to_api_url(url: Url) -> Result<Url, Error> {
 mod tests {
     use super::*;
     use anyhow::Result;
-
     use url::Url;
-
-    struct MockHttpClient {}
-
-    impl GetAllBytes for MockHttpClient {
-        fn get_bytes(
-            &self,
-            urls: impl Iterator<Item = Url>,
-        ) -> std::result::Result<Vec<Result<Vec<u8>, HttpClientError>>, Error> {
-            let result: Vec<Result<Vec<u8>, HttpClientError>> = urls
-                .map(|_| {
-                    let body: Vec<u8> = Default::default();
-                    let response =
-                        http::Response::builder().status(500).body(body).unwrap();
-                    let response: reqwest::Response = response.into();
-                    let error = response.error_for_status().err().unwrap();
-                    Err(HttpClientError::Request { error })
-                })
-                .collect();
-            Ok(result)
-        }
-    }
-
-    #[test]
-    fn none_on_request_error() -> Result<()> {
-        let urls: Vec<Url> = vec![
-            "https://app.uniswap.org/#/swap?chain=mainnet",
-            "https://app.ens.domains/",
-        ]
-        .iter()
-        .map(|s| Url::parse(s).unwrap())
-        .collect();
-        let count = urls.len();
-        let client = MockHttpClient {};
-        let results = fetch_favicons(&client, urls)?;
-        assert_eq!(results.len(), count);
-        for res in results {
-            assert!(res.is_none())
-        }
-
-        Ok(())
-    }
 
     #[test]
     fn dapp_url_to_api_url_expected() -> Result<()> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,19 +11,19 @@ extern crate lazy_static;
 extern crate num_derive;
 
 // These are public, because they're used by the dev server
+pub mod app_core;
 pub mod assets;
 pub mod async_runtime;
 pub mod config;
-pub mod in_page_provider;
-
-pub mod app_core;
-mod db;
 pub mod dto;
+pub mod in_page_provider;
+pub mod protocols;
+
+mod db;
 mod encryption;
 mod error;
 mod favicon;
 mod http_client;
-pub mod protocols;
 mod public_suffix_list;
 mod signatures;
 mod utils;

--- a/core/src/protocols/eth/ankr.rs
+++ b/core/src/protocols/eth/ankr.rs
@@ -8,13 +8,17 @@ use crate::protocols::TokenType;
 use crate::Error;
 use ethers::types::{Address, U256};
 use jsonrpsee::core::{async_trait, RpcResult};
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::http_client::HttpClient;
+// Behind flag otherwise `cargo fix` removes it
+#[cfg(not(test))]
+use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::types::error::{ErrorCode};
+use jsonrpsee::types::error::ErrorCode;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 // Port number is important for, otherwise Jsonrpsee HTTP client doesn't work
+#[cfg(not(test))]
 const ANKR_API: &str = "https://rpc.ankr.com:443/multichain";
 const PAGE_SIZE: usize = 100;
 
@@ -26,7 +30,6 @@ trait AnkrRpcApi {
     async fn get_account_balances(
         &self,
         blockchain: Vec<AnkrBlockchain>,
-        // Need to be camel case for correct generated code
         pageSize: usize,
         pageToken: Option<&str>,
         walletAddress: &str,
@@ -255,7 +258,7 @@ pub use tests::AnkrRpc;
 mod tests {
     use super::*;
 
-    use crate::{async_runtime as rt};
+    use crate::async_runtime as rt;
     use jsonrpsee::core::logger::{Body, HttpLogger, MethodKind, Params, Request};
     use jsonrpsee::core::{async_trait, RpcResult};
     use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -277,7 +280,7 @@ mod tests {
                     .set_logger(ServerLogger)
                     .build("127.0.0.1:0"),
             )
-                .expect("can build server");
+            .expect("can build server");
             let server_addr = server.local_addr().expect("has local address");
             let url = format!("http://{}", server_addr);
             let server_handle = server
@@ -309,10 +312,10 @@ mod tests {
     impl AnkrRpcApiServer for AnkrRpcApiServerImpl {
         async fn get_account_balances(
             &self,
-            blockchain: Vec<AnkrBlockchain>,
-            pageSize: usize,
+            _blockchain: Vec<AnkrBlockchain>,
+            _pageSize: usize,
             pageToken: Option<&str>,
-            walletAddress: &str,
+            _walletAddress: &str,
         ) -> RpcResult<AnkrTokenBalances> {
             // Simulate paging once
             let page_token = if pageToken.is_none() {
@@ -323,49 +326,49 @@ mod tests {
 
             let balances = if pageToken.is_none() {
                 json!([
-              {
-                "blockchain": "polygon",
-                "tokenName": "USD Coin (PoS)",
-                "tokenSymbol": "USDC",
-                "tokenDecimals": 6,
-                "tokenType": "ERC20",
-                "contractAddress": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
-                "holderAddress": "0x12d7dacca565ee7581f6bbf1eb8f5ccbb456ef19",
-                "balance": "0.119157",
-                "balanceRawInteger": "119157",
-                "balanceUsd": "0.119157",
-                "tokenPrice": "1",
-                "thumbnail": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png"
-              },
-              {
-                "blockchain": "polygon",
-                "tokenName": "Polygon",
-                "tokenSymbol": "MATIC",
-                "tokenDecimals": 18,
-                "tokenType": "NATIVE",
-                "holderAddress": "0x12d7dacca565ee7581f6bbf1eb8f5ccbb456ef19",
-                "balance": "0.941696667609996629",
-                "balanceRawInteger": "941696667609996629",
-                "balanceUsd": "0",
-                "tokenPrice": "0",
-                "thumbnail": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
-              },
-            ])
+                  {
+                    "blockchain": "polygon",
+                    "tokenName": "USD Coin (PoS)",
+                    "tokenSymbol": "USDC",
+                    "tokenDecimals": 6,
+                    "tokenType": "ERC20",
+                    "contractAddress": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+                    "holderAddress": "0x12d7dacca565ee7581f6bbf1eb8f5ccbb456ef19",
+                    "balance": "0.119157",
+                    "balanceRawInteger": "119157",
+                    "balanceUsd": "0.119157",
+                    "tokenPrice": "1",
+                    "thumbnail": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png"
+                  },
+                  {
+                    "blockchain": "polygon",
+                    "tokenName": "Polygon",
+                    "tokenSymbol": "MATIC",
+                    "tokenDecimals": 18,
+                    "tokenType": "NATIVE",
+                    "holderAddress": "0x12d7dacca565ee7581f6bbf1eb8f5ccbb456ef19",
+                    "balance": "0.941696667609996629",
+                    "balanceRawInteger": "941696667609996629",
+                    "balanceUsd": "0",
+                    "tokenPrice": "0",
+                    "thumbnail": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                ])
             } else {
                 json!([{
-                "blockchain": "polygon",
-                "tokenName": "Space Protocol",
-                "tokenSymbol": "SPL",
-                "tokenDecimals": 18,
-                "tokenType": "ERC20",
-                "contractAddress": "0xfec6832ab7bea7d3db02472b64cb59cfc6f2c107",
-                "holderAddress": "0x12d7dacca565ee7581f6bbf1eb8f5ccbb456ef19",
-                "balance": "500",
-                "balanceRawInteger": "500000000000000000000",
-                "balanceUsd": "0",
-                "tokenPrice": "0",
-                "thumbnail": ""
-            }])
+                    "blockchain": "polygon",
+                    "tokenName": "Space Protocol",
+                    "tokenSymbol": "SPL",
+                    "tokenDecimals": 18,
+                    "tokenType": "ERC20",
+                    "contractAddress": "0xfec6832ab7bea7d3db02472b64cb59cfc6f2c107",
+                    "holderAddress": "0x12d7dacca565ee7581f6bbf1eb8f5ccbb456ef19",
+                    "balance": "500",
+                    "balanceRawInteger": "500000000000000000000",
+                    "balanceUsd": "0",
+                    "tokenPrice": "0",
+                    "thumbnail": ""
+                }])
             };
 
             let balances: Vec<AnkrTokenBalance> =

--- a/core/src/protocols/eth/mod.rs
+++ b/core/src/protocols/eth/mod.rs
@@ -5,6 +5,8 @@
 use crate::signatures::AsymmetricKey;
 use k256::Secp256k1;
 
+// Some names need to be be camel case in ankr for generated code.
+#[allow(non_snake_case)]
 pub mod ankr;
 mod chain_id;
 mod chain_settings;

--- a/core/src/protocols/eth/signer.rs
+++ b/core/src/protocols/eth/signer.rs
@@ -47,11 +47,6 @@ impl<'a> Signer<'a> {
 
     /// Make sure transaction parameters match our address data.
     fn verify_tx_params(&self, tx: &TypedTransaction) -> Result<(), Error> {
-        println!(
-            "tx.from() {:?}, self.address() {:?}",
-            tx.from(),
-            self.address()
-        );
         if tx.from() != Some(&self.address()) {
             return Err(Error::Fatal {
                 error: "Wrong from in tx params".into(),

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -80,8 +80,7 @@ pub fn uri_fixup(input: impl AsRef<str>) -> Option<String> {
         return None;
     }
 
-    let url =
-        Url::parse(trimmed).or_else(|_| Url::parse(&format!("http://{}", trimmed)));
+    let url = Url::parse(trimmed).or_else(|_| Url::parse(&format!("http://{}", trimmed)));
 
     url.ok().and_then(|u| {
         if !ALLOWED_SCHEMES.contains(u.scheme()) {

--- a/ios/SealVaultApp/Config.swift
+++ b/ios/SealVaultApp/Config.swift
@@ -7,7 +7,7 @@ import Foundation
 struct Config {
     static let dbFileDir = "database"
     static let dbFileName = "sealvault-db.sqlite3"
-    static let defaultHomePage = "https://search.brave.com"
+    static let defaultHomePage = "http://localhost:8080"
     static let searchProvider = URL(string: "https://search.brave.com/search")!
     static let searchQueryParamName = "q"
 }

--- a/ios/SealVaultApp/Model/GlobalModel.swift
+++ b/ios/SealVaultApp/Model/GlobalModel.swift
@@ -175,7 +175,7 @@ class PreviewAppCore: AppCoreProtocol {
         throw CoreError.Fatal(message: "not implemented")
     }
 
-    func inPageRequest(context _: InPageRequestContextI, rawRequest _: String) throws -> String {
+    func inPageRequest(context _: InPageRequestContextI, rawRequest _: String) throws {
         throw CoreError.Fatal(message: "not implemented")
     }
 }

--- a/tools/dev-server/Cargo.toml
+++ b/tools/dev-server/Cargo.toml
@@ -13,4 +13,5 @@ actix-files = "0.6.1"
 env_logger = "0.9.0"
 ethers-core = { version = "0.17", features = ["legacy", "eip712"] }
 dotenv = "0.15.0"
+log = { version = "0.4.17", features = ["serde"] }
 tokio = "1.20.1"

--- a/tools/dev-server/static/ethereum.html
+++ b/tools/dev-server/static/ethereum.html
@@ -40,7 +40,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             },
             body,
           })
-          return response.text()
+          const text = await response.text()
+          window[SEALVAULT_RPC_PROVIDER].respond(text)
         }
 
         window[SEALVAULT_REQUEST_HANDLER] = postMessage
@@ -66,7 +67,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       // Returns the event data.
       function blockOnEvent(event) {
         return new Promise((resolve, reject) => {
-          window.ethereum.on(event, data => {
+          window.ethereum.on(event, (data) => {
             resolve(data)
           })
           window.setTimeout(reject, BLOCK_ON_EVENT_SECONDS * 1000)
@@ -77,9 +78,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         assert(!!window.ethereum)
       })
 
-      test("isMetaMask", () =>
-        assert(!!window.ethereum.isMetaMask)
-      )
+      test("isMetaMask", () => assert(!!window.ethereum.isMetaMask))
 
       test("networkVersion", () => {
         assert(Number.isFinite(parseInt(window.ethereum.networkVersion)))
@@ -96,7 +95,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         let ok = false
         try {
           await window.ethereum.request({
-            method: "eth_chainId"
+            method: "eth_chainId",
           })
         } catch (e) {
           assertEq(e.code, 4100)
@@ -159,16 +158,16 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
       test("wallet_addEthereumChain", async (method) => {
         let args = {
-          chainId: '0x1',
-          rpcUrls: ['https://mainnet.infura.io/v3/'],
-          chainName: 'Ethereum',
-          nativeCurrency: { name: 'Ethereum', decimals: 18, symbol: 'ETH' },
+          chainId: "0x1",
+          rpcUrls: ["https://mainnet.infura.io/v3/"],
+          chainName: "Ethereum",
+          nativeCurrency: { name: "Ethereum", decimals: 18, symbol: "ETH" },
           blockExplorerUrls: "https://etherescan.io",
         }
 
         const result = await window.ethereum.request({
           method,
-          params: [args]
+          params: [args],
         })
         // Null means success
         assertEq(result, null)
@@ -179,7 +178,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         let changedChainId = blockOnEvent("chainChanged")
         await window.ethereum.request({
           method,
-          params: [{chainId: goerli}]
+          params: [{ chainId: goerli }],
         })
         changedChainId = await changedChainId
         assertEq(changedChainId, goerli)
@@ -191,9 +190,9 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       })
 
       test("eth_sendTransaction", async (method) => {
-        const chain_id = await window.ethereum.request({method: "eth_chainId"})
-        const accounts = await window.ethereum.request({method: "eth_requestAccounts"})
-        const gasPrice = await window.ethereum.request({method: "eth_gasPrice"})
+        const chain_id = await window.ethereum.request({ method: "eth_chainId" })
+        const accounts = await window.ethereum.request({ method: "eth_requestAccounts" })
+        const gasPrice = await window.ethereum.request({ method: "eth_gasPrice" })
         // From MM docs: https://archive.ph/9DUcC
         const params = {
           nonce: "0x00",
@@ -202,15 +201,14 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           from: accounts[0],
           value: "0x00",
           gas: "0x2f372",
-          data:
-                  "0x7f7465737432000000000000000000000000000000000000000000000000000000600057", // Optional, but used for defining smart contract creation and interaction.
+          data: "0x7f7465737432000000000000000000000000000000000000000000000000000000600057", // Optional, but used for defining smart contract creation and interaction.
           chain_id,
-        };
+        }
         let threw = false
         try {
           const txHash = await window.ethereum.request({
             method,
-            params: [params]
+            params: [params],
           })
         } catch (e) {
           console.error(e, `e.message: ${e.message}`)
@@ -222,10 +220,10 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       })
 
       test("personal_sign", async (method) => {
-        const accounts = await window.ethereum.request({method: "eth_requestAccounts"})
+        const accounts = await window.ethereum.request({ method: "eth_requestAccounts" })
         const signature = await window.ethereum.request({
           method,
-          params: ["0xabcd1234", accounts[0], "ignored-password"]
+          params: ["0xabcd1234", accounts[0], "ignored-password"],
         })
         assert(signature.startsWith("0x"), "signature must start with 0x")
       })
@@ -240,18 +238,24 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       test("eth_estimateGas", async (method) => {
         const gas = await window.ethereum.request({
           method,
-          params: [{"from":"0x8D97689C9818892B700e27F316cc3E41e17fBeb9","to":"0xd3CdA913deB6f67967B99D67aCDFa1712C293601","value":"0x186a0"}]
+          params: [
+            {
+              from: "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
+              to: "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+              value: "0x186a0",
+            },
+          ],
         })
         assert(gas.startsWith("0x"), `Expected '${gas}' to start with 0x`)
       })
 
       test("eth_getBlockByNumber", async (method) => {
         const blockNumber = await window.ethereum.request({
-          method: "eth_blockNumber"
+          method: "eth_blockNumber",
         })
         const block = await window.ethereum.request({
           method,
-          params: [blockNumber, true]
+          params: [blockNumber, true],
         })
         assertEq(block.number, blockNumber)
         assert(Array.isArray(block.transactions), "block.transactions should be an array")
@@ -267,7 +271,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       test("web3_sha3", async (method) => {
         const hash = await window.ethereum.request({
           method,
-          params: ["0xabcd"]
+          params: ["0xabcd"],
         })
         assert(hash.startsWith("0x"))
       })
@@ -276,7 +280,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         const request = {
           id: `sendAsync-id-${Date.now()}`,
           jsonrpc: "2.0",
-          method: "eth_chainId"
+          method: "eth_chainId",
         }
         const chain_id = await new Promise((resolve, reject) => {
           window.ethereum.sendAsync(request, (error, result) => {
@@ -294,7 +298,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         const request = {
           id: `send-id-${Date.now()}`,
           jsonrpc: "2.0",
-          method: "eth_chainId"
+          method: "eth_chainId",
         }
         const chain_id_first = await new Promise((resolve, reject) => {
           window.ethereum.send(request, (error, result) => {
@@ -313,7 +317,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         let ok = false
         try {
           await window.ethereum.request({
-            method: "eth_sign"
+            method: "eth_sign",
           })
         } catch (e) {
           assertEq(e.code, 4200)

--- a/website/src/dev-docs/rust.md
+++ b/website/src/dev-docs/rust.md
@@ -41,7 +41,7 @@ async Rust has some rough edges which we can avoid this way.  For this reason,
 our Rust code is written as single threaded, blocking code and concurrency is
 handled by the host languages. 
 
-There are two exceptions:
+There are three exceptions:
 
 1. Some of our Rust dependencies only expose async interfaces. In this case we
 block on them with the `async_runtime` module that wraps a lazy-initialized
@@ -50,3 +50,8 @@ global Tokio runtime.
 function that we want to call multiple times concurrently during one FFI call
 (eg. to fetch multiple images), then we write that function as async, spawn
 instances of it on the async runtime and then block on the joined futures.
+3. While initially the in-page provider was implemented with the blocking 
+approach, we discovered that it's surprisingly difficult to get a fixed-sized
+dedicated thread-pool in Swift and one request at a time is not good enough 
+performance-wise, so we've refactored it to async in Rust and callback-based 
+through FFI. 


### PR DESCRIPTION
While initially the in-page provider was implemented with the blocking approach, we discovered that it's surprisingly difficult to get a fixed-sized dedicated thread-pool in Swift and one request at a time is not good enough performance-wise, so we've refactored it to async in Rust and callback-based through FFI.