### PR TITLE
Add long-press to copy address on ProfileRow.

### DIFF
--- a/ios/SealVaultApp/ProfileListView.swift
+++ b/ios/SealVaultApp/ProfileListView.swift
@@ -19,6 +19,13 @@ struct ProfileListView: View {
                             ProfileRow(profile: profile)
                                 .padding(.vertical, 8)
                                 .accessibilityIdentifier("\(profile.displayName) profile")
+                                .contextMenu {
+                                    Button(action: {
+                                        UIPasteboard.general.string = profile.walletList.first?.checksumAddress
+                                    }, label: {
+                                        Text("Copy wallet address")
+                                    })
+                                }
                         }
                     }
                 }

--- a/ios/SealVaultApp/ProfileRow.swift
+++ b/ios/SealVaultApp/ProfileRow.swift
@@ -6,6 +6,7 @@ import SwiftUI
 
 struct ProfileRow: View {
     @ObservedObject var profile: Profile
+    @State private var showCopyFeedback = false
 
     private let cornerRadius: Double = 10
     private let maxDapps = 3
@@ -27,8 +28,16 @@ struct ProfileRow: View {
         }
         .font(.subheadline)
         .accessibilityElement(children: .combine)
-    }
-}
+        .overlay(Text("Copied address").font(.footnote).opacity(showCopyFeedback ? 1 : 0), alignment: .topTrailing)
+        .onLongPressGesture {
+            UIPasteboard.general.string = profile.walletList.first?.checksumAddress
+            showCopyFeedback = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                showCopyFeedback = false
+            }
+        }
+
+    }}
 
 #if DEBUG
 struct ProfileRow_Previews: PreviewProvider {

--- a/ios/SealVaultApp/ProfileRow.swift
+++ b/ios/SealVaultApp/ProfileRow.swift
@@ -6,7 +6,6 @@ import SwiftUI
 
 struct ProfileRow: View {
     @ObservedObject var profile: Profile
-    @State private var showCopyFeedback = false
 
     private let cornerRadius: Double = 10
     private let maxDapps = 3
@@ -28,16 +27,8 @@ struct ProfileRow: View {
         }
         .font(.subheadline)
         .accessibilityElement(children: .combine)
-        .overlay(Text("Copied address").font(.footnote).opacity(showCopyFeedback ? 1 : 0), alignment: .topTrailing)
-        .onLongPressGesture {
-            UIPasteboard.general.string = profile.walletList.first?.checksumAddress
-            showCopyFeedback = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                showCopyFeedback = false
-            }
-        }
-
-    }}
+    }
+}
 
 #if DEBUG
 struct ProfileRow_Previews: PreviewProvider {


### PR DESCRIPTION
This is my attempt at addressing issue #70. Happy to take feedback especially since I haven't done any iOS development in 5 years, and I'm not familiar with what the best practices are within SwiftUI, or for visual feedback on an action like this.

![Simulator Screen Recording - iPhone 14 Pro - 2022-12-27 at 14 40 56](https://user-images.githubusercontent.com/13524606/209715028-e7e1e2c8-a9aa-4707-9f1d-16832ff1c62c.gif)
