### PR TITLE
Lazy load favicons

### DIFF
--- a/core/src/SealVaultCore.udl
+++ b/core/src/SealVaultCore.udl
@@ -25,7 +25,7 @@ interface AppCore {
     i64? last_uploaded_backup();
 
     [Throws=CoreError]
-    sequence<CoreProfile> list_profiles();
+    sequence<CoreProfile> list_profiles(boolean fetch_dapp_icons);
 
     [Throws=CoreError]
     void create_profile(string name, string bundled_picture_name);

--- a/core/src/app_core.rs
+++ b/core/src/app_core.rs
@@ -165,8 +165,12 @@ impl AppCore {
         Ok(res)
     }
 
-    pub fn list_profiles(&self) -> Result<Vec<dto::CoreProfile>, CoreError> {
-        let res = self.assembler().assemble_profiles()?;
+    /// See `assemble_profiles` for details.
+    pub fn list_profiles(
+        &self,
+        fetch_dapp_icons: bool,
+    ) -> Result<Vec<dto::CoreProfile>, CoreError> {
+        let res = self.assembler().assemble_profiles(fetch_dapp_icons)?;
         Ok(res)
     }
 
@@ -860,7 +864,7 @@ pub mod tests {
         }
 
         pub fn first_profile(&self) -> dto::CoreProfile {
-            let profiles = self.core.list_profiles().expect("cannot list profiles");
+            let profiles = self.core.list_profiles(true).expect("cannot list profiles");
             profiles.into_iter().next().expect("there is one profile")
         }
 
@@ -1285,17 +1289,17 @@ pub mod tests {
         let tmp = TmpCore::new()?;
 
         let first_profile = tmp.first_profile();
-        let initial_count = tmp.core.list_profiles()?.len();
+        let initial_count = tmp.core.list_profiles(true)?.len();
 
         let name = "foo".to_string();
         tmp.core.create_profile(name.clone(), "seal-1".into())?;
-        let profiles = tmp.core.list_profiles()?;
+        let profiles = tmp.core.list_profiles(true)?;
         assert_eq!(profiles.len(), initial_count + 1);
         assert_eq!(profiles[initial_count].name, name);
 
         let name = "bar".to_string();
         tmp.core.create_profile(name.clone(), "seal-2".into())?;
-        let profiles = tmp.core.list_profiles()?;
+        let profiles = tmp.core.list_profiles(true)?;
         assert_eq!(profiles.len(), initial_count + 2);
         assert_eq!(profiles[initial_count + 1].name, name);
 
@@ -1345,7 +1349,7 @@ pub mod tests {
         let keychain = core.resources.keychain();
 
         core.create_profile("profile-two".into(), "seal-1".into())?;
-        let profiles = core.list_profiles()?;
+        let profiles = core.list_profiles(true)?;
         assert_eq!(profiles.len(), 2);
 
         let profile_id_one: DeterministicId = profiles[0].id.clone().try_into()?;

--- a/core/src/favicon.rs
+++ b/core/src/favicon.rs
@@ -31,6 +31,19 @@ pub fn fetch_favicons(
     rt::block_on(fetch_favicons_async(client, urls))
 }
 
+/// Fetch favicons in the background without blocking to warm the cache.
+/// Returns none for each url.
+pub fn warm_favicons_cache(
+    client: HttpClient,
+    urls: Vec<Url>,
+) -> Result<Vec<Option<Vec<u8>>>, Error> {
+    let results = urls.iter().map(|_| None).collect();
+    rt::spawn(async move {
+        let _ = fetch_favicons_async(&client, urls).await;
+    });
+    Ok(results)
+}
+
 /// Fetch one favicon from the DuckDuckGo favicon api.
 /// Uses local cache and returns None if there was an error fetching the favicon.
 pub async fn fetch_favicon_async(

--- a/core/src/http_client.rs
+++ b/core/src/http_client.rs
@@ -11,7 +11,7 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 
 use crate::{config, Error};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HttpClient {
     client: ClientWithMiddleware,
 }

--- a/ios/SealVaultApp/DappApproval.swift
+++ b/ios/SealVaultApp/DappApproval.swift
@@ -143,7 +143,7 @@ struct DappApproval_Previews: PreviewProvider {
         let model = GlobalModel.buildForPreview()
         let profileId = model.activeProfileId!
         let dapp = Dapp.quickswap()
-        let favicon = [UInt8](dapp.favicon.pngData()!)
+        let favicon = [UInt8](dapp.favicon!.pngData()!)
         let params = DappApprovalParams(
             profileId: profileId, dappIdentifier: dapp.humanIdentifier, favicon: favicon, amount: "0.1",
             transferAllotment: true, tokenSymbol: "MATIC", chainDisplayName: "Polygon PoS", chainId: 137,

--- a/ios/SealVaultApp/DappRow.swift
+++ b/ios/SealVaultApp/DappRow.swift
@@ -12,8 +12,12 @@ struct DappRow: View {
             Text(dapp.displayName)
                 .font(.headline)
         } icon: {
-            IconView(image: dapp.image, iconSize: 24)
-                .accessibility(label: Text("Dapp icon"))
+            if let image = dapp.image {
+                IconView(image: image, iconSize: 24)
+                    .accessibility(label: Text("Dapp icon"))
+            } else {
+                ProgressView()
+            }
         }
     }
 }

--- a/ios/SealVaultApp/Model/Dapp.swift
+++ b/ios/SealVaultApp/Model/Dapp.swift
@@ -19,7 +19,7 @@ class Dapp: Identifiable, ObservableObject {
     @Published var lastUsed: String?
 
     /// Favicon
-    @Published var favicon: UIImage
+    @Published var favicon: UIImage?
 
     required init(
         _ core: AppCoreProtocol, id: String, profileId: String, humanIdentifier: String, url: URL?,
@@ -94,8 +94,8 @@ extension Dapp {
         humanIdentifier
     }
 
-    var image: Image {
-        Image(uiImage: favicon)
+    var image: Image? {
+        favicon.map {Image(uiImage: $0)}
     }
 }
 

--- a/ios/SealVaultApp/SealVaultApp.swift
+++ b/ios/SealVaultApp/SealVaultApp.swift
@@ -30,7 +30,9 @@ struct AppInner: View {
             .environmentObject(model)
             .environmentObject(bannerModel)
             .task {
-                await model.refreshProfiles()
+                // We aren't fetching dapp icons here because that'd make blocking
+                // network requests and we want to show profiles asap on startup.
+                await model.refreshProfiles(fetchDappIcons: false)
 
                 #if DEBUG
                 if CommandLine.arguments.contains(Config.createProfileArg) {


### PR DESCRIPTION
Don't load favicons when the application starts when fetching profiles to avoid blocking on network requests on startup, but warm the favicon cache to make subsequent requests fast.