### PR TITLE
Support fetching fungible token balances through Ethereum RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,6 +4340,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.0",
  "blake3",
+ "bytes",
  "cacache",
  "chacha20poly1305",
  "chrono",
@@ -4386,6 +4387,7 @@ dependencies = [
  "strum_macros",
  "subtle",
  "tempfile",
+ "test-log",
  "thiserror",
  "tokio",
  "typed-builder",
@@ -4958,6 +4960,17 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ publicsuffix = "2.2.3"
 rand = "0.8.5"
 readonly = "0.2.4"
 regex = "1.7.1"
-reqwest = { version = "0.11.14" }
+reqwest = { version = "0.11.14", features = ["json"] }
 reqwest-middleware = "0.2.0"
 rust-embed = "6.6.0"
 rust_decimal = { version = "1.28.1", features = ["maths"] }
@@ -75,6 +75,7 @@ zeroize = { version = "1.5.7", features = ["derive"] }
 zip = "0.6.4"
 
 core_macros = { path = "../core_macros" }
+bytes = { version = "1.4.0", features = ["serde"] }
 
 [build-dependencies]
 # Important to match uniffi dep version in `embedded-uniff-bindgen`
@@ -83,3 +84,4 @@ uniffi = { version = "0.23.0", features = ["build"] }
 [dev-dependencies]
 anyhow = { version = "1.0.69", features = ["backtrace"] }
 ethers = { version = "2.0.0", features = ["legacy", "eip712", "abigen-offline", "solc-full"] }
+test-log = "0.2.11"

--- a/core/src/db/models/mod.rs
+++ b/core/src/db/models/mod.rs
@@ -39,4 +39,4 @@ pub use local_encrypted_dek::{LocalEncryptedDek, NewLocalEncryptedDek};
 pub use local_settings::LocalSettings;
 pub use profile::{Profile, ProfileEntity, ProfileName};
 pub use profile_picture::{ProfilePicture, ProfilePictureEntity};
-pub use token::Token;
+pub use token::{EthTokensForAddress, Token};

--- a/core/src/db/models/token.rs
+++ b/core/src/db/models/token.rs
@@ -217,7 +217,6 @@ mod tests {
             amount: Default::default(),
             decimals: 0,
             symbol: "".to_string(),
-            name: "".to_string(),
             logo: None,
         }];
 

--- a/core/src/dto.rs
+++ b/core/src/dto.rs
@@ -496,9 +496,8 @@ impl Assembler {
         &self,
         address: eth::ChecksumAddress,
     ) -> Result<Vec<CoreTokens>, Error> {
-        use ankr::AnkrRpcI;
-        let ankr_api = ankr::AnkrRpc::new()?;
-        let token_balances = rt::block_on(ankr_api.get_token_balances(address))?;
+        let ankr_api = ankr::AnkrApi::new()?;
+        let token_balances = rt::block_on(ankr_api.fetch_token_balances(address))?;
 
         self.connection_pool().deferred_transaction(|mut tx_conn| {
             let mut results: Vec<CoreTokens> = Default::default();

--- a/core/src/dto.rs
+++ b/core/src/dto.rs
@@ -343,7 +343,7 @@ impl Assembler {
         address: eth::ChecksumAddress,
     ) -> Result<Vec<CoreTokens>, Error> {
         self.assemble_tokens(address).or_else(|error| {
-            log::error!("Error fetching tokens from Ankr API: '{error}'");
+            log::error!("Error fetching tokens: '{error}'");
             // Fall back to just fetching native token
             self.assemble_native_tokens(address)
         })

--- a/core/src/protocols/eth/ankr.rs
+++ b/core/src/protocols/eth/ankr.rs
@@ -28,10 +28,7 @@ use url::Url;
 
 use crate::{
     protocols::{
-        eth::{
-            token::FungibleTokenBalance, ChainId, NFTBalance, NativeTokenAmount,
-            TokenBalances,
-        },
+        eth::{ChainId, NativeTokenAmount},
         FungibleTokenType,
     },
     Error,
@@ -494,7 +491,10 @@ impl From<AnkrTokenType> for FungibleTokenType {
 #[cfg(test)]
 pub use tests::AnkrRpc;
 
-use crate::protocols::eth::ChecksumAddress;
+use crate::protocols::eth::{
+    token_balances::{FungibleTokenBalance, NFTBalance, TokenBalances},
+    ChecksumAddress,
+};
 
 #[cfg(test)]
 mod tests {

--- a/core/src/protocols/eth/ankr.rs
+++ b/core/src/protocols/eth/ankr.rs
@@ -299,7 +299,7 @@ impl TryFrom<AnkrFungibleTokenBalance> for FungibleTokenBalance {
             token_decimals,
             blockchain,
             token_symbol,
-            token_name,
+
             thumbnail,
             ..
         } = value;
@@ -315,7 +315,6 @@ impl TryFrom<AnkrFungibleTokenBalance> for FungibleTokenBalance {
             amount: balance_raw_integer.into(),
             decimals: token_decimals,
             symbol: token_symbol,
-            name: token_name,
             logo,
         })
     }
@@ -492,7 +491,7 @@ impl From<AnkrTokenType> for FungibleTokenType {
 pub use tests::AnkrRpc;
 
 use crate::protocols::eth::{
-    token_balances::{FungibleTokenBalance, NFTBalance, TokenBalances},
+    token_api::{FungibleTokenBalance, NFTBalance, TokenBalances},
     ChecksumAddress,
 };
 

--- a/core/src/protocols/eth/contracts/mod.rs
+++ b/core/src/protocols/eth/contracts/mod.rs
@@ -63,6 +63,10 @@ pub mod test_util {
             wallet.with_chain_id(self.chain_id)
         }
 
+        pub fn deployer_address(&self) -> ChecksumAddress {
+            self.deployer_wallet().address().into()
+        }
+
         pub fn provider(&self) -> Provider<Http> {
             self.rpc_provider.provider.clone()
         }

--- a/core/src/protocols/eth/mod.rs
+++ b/core/src/protocols/eth/mod.rs
@@ -20,6 +20,7 @@ mod protocol_data;
 mod rpc_provider;
 mod signer;
 mod token;
+mod token_balances;
 
 pub type EthereumAsymmetricKey = AsymmetricKey<Secp256k1>;
 pub use chain_id::ChainId;
@@ -31,7 +32,5 @@ pub use protocol_data::ProtocolData;
 pub use rpc_provider::anvil::AnvilRpcManager;
 pub use rpc_provider::{RpcManager, RpcManagerI, RpcProvider};
 pub use signer::Signer;
-pub use token::{
-    FungibleTokenAmount, FungibleTokenBalance, NFTBalance, NativeTokenAmount,
-    TokenBalances,
-};
+pub use token::{FungibleTokenAmount, NativeTokenAmount};
+pub use token_balances::{FungibleTokenBalance, NFTBalance, TokenBalances};

--- a/core/src/protocols/eth/mod.rs
+++ b/core/src/protocols/eth/mod.rs
@@ -33,4 +33,6 @@ pub use rpc_provider::anvil::AnvilRpcManager;
 pub use rpc_provider::{RpcManager, RpcManagerI, RpcProvider};
 pub use signer::Signer;
 pub use token::{FungibleTokenAmount, NativeTokenAmount};
-pub use token_api::{FungibleTokenBalance, NFTBalance, TokenBalances};
+pub use token_api::{
+    fetch_token_balances, FungibleTokenBalance, NFTBalance, TokenBalances,
+};

--- a/core/src/protocols/eth/mod.rs
+++ b/core/src/protocols/eth/mod.rs
@@ -20,7 +20,7 @@ mod protocol_data;
 mod rpc_provider;
 mod signer;
 mod token;
-mod token_balances;
+mod token_api;
 
 pub type EthereumAsymmetricKey = AsymmetricKey<Secp256k1>;
 pub use chain_id::ChainId;
@@ -33,4 +33,4 @@ pub use rpc_provider::anvil::AnvilRpcManager;
 pub use rpc_provider::{RpcManager, RpcManagerI, RpcProvider};
 pub use signer::Signer;
 pub use token::{FungibleTokenAmount, NativeTokenAmount};
-pub use token_balances::{FungibleTokenBalance, NFTBalance, TokenBalances};
+pub use token_api::{FungibleTokenBalance, NFTBalance, TokenBalances};

--- a/core/src/protocols/eth/rpc_provider.rs
+++ b/core/src/protocols/eth/rpc_provider.rs
@@ -260,6 +260,7 @@ impl RpcProvider {
 
 /// A trait to let us inject dynamic Anvil url at test time.
 pub trait RpcManagerI: Debug + Send + Sync {
+    fn http_endpoint(&self, chain_id: ChainId) -> Url;
     fn eth_api_provider(&self, chain_id: ChainId) -> RpcProvider;
 }
 
@@ -284,6 +285,10 @@ impl Debug for RpcManager {
 }
 
 impl RpcManagerI for RpcManager {
+    fn http_endpoint(&self, chain_id: ChainId) -> Url {
+        chain_id.http_rpc_endpoint()
+    }
+
     fn eth_api_provider(&self, chain_id: ChainId) -> RpcProvider {
         let http_endpoint = chain_id.http_rpc_endpoint();
         RpcProvider::new(chain_id, http_endpoint)
@@ -399,6 +404,10 @@ pub mod anvil {
     }
 
     impl RpcManagerI for AnvilRpcManager {
+        fn http_endpoint(&self, chain_id: ChainId) -> Url {
+            self.anvil_endpoint(chain_id)
+        }
+
         fn eth_api_provider(&self, chain_id: ChainId) -> RpcProvider {
             let http_endpoint = self.anvil_endpoint(chain_id);
             let mut provider = RpcProvider::new(chain_id, http_endpoint);

--- a/core/src/protocols/eth/token.rs
+++ b/core/src/protocols/eth/token.rs
@@ -129,7 +129,7 @@ impl FungibleTokenAmount {
 
 /// Based on
 /// https://github.com/gakonst/ethers-rs/blob/3681099af328610b429fd22eab5e9f68f693c60c/ethers-core/src/utils/mod.rs#L101
-fn display_amount(amount: U256, decimals: u8) -> String {
+pub(super) fn display_amount(amount: U256, decimals: u8) -> String {
     let decimals_us: usize = decimals.into();
     let scale = U256::exp10(decimals_us);
 
@@ -180,53 +180,6 @@ fn parse_amount(amount: &str, decimals: u8) -> Result<U256, Error> {
     U256::from_dec_str(&val.round().to_string()).map_err(|_| Error::Retriable {
         error: format!("Cannot parse {} as U256", val),
     })
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FungibleTokenBalance {
-    pub chain_id: ChainId,
-    pub contract_address: ChecksumAddress,
-    pub amount: U256,
-    pub decimals: u8,
-    pub symbol: String,
-    pub name: String,
-    pub logo: Option<url::Url>,
-}
-
-impl FungibleTokenBalance {
-    pub fn display_amount(&self) -> String {
-        display_amount(self.amount, self.decimals)
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct NFTBalance {
-    pub chain_id: ChainId,
-    pub contract_address: ChecksumAddress,
-    pub symbol: String,
-    pub collection_name: String,
-    pub name: String,
-    pub token_id: String,
-    pub image_url: Option<url::Url>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct TokenBalances {
-    pub chain_id: ChainId,
-    pub native_token: NativeTokenAmount,
-    pub fungible_tokens: Vec<FungibleTokenBalance>,
-    pub nfts: Vec<NFTBalance>,
-}
-
-impl TokenBalances {
-    pub fn default_for_chain(chain_id: ChainId) -> Self {
-        TokenBalances {
-            chain_id,
-            native_token: NativeTokenAmount::zero_balance(chain_id),
-            fungible_tokens: Vec::new(),
-            nfts: Vec::new(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/core/src/protocols/eth/token_api/mod.rs
+++ b/core/src/protocols/eth/token_api/mod.rs
@@ -4,4 +4,79 @@
 mod native;
 mod token_balances;
 
+use std::collections::HashMap;
+
+use futures::StreamExt;
+use strum::IntoEnumIterator;
 pub use token_balances::{FungibleTokenBalance, NFTBalance, TokenBalances};
+
+use crate::{
+    db::models as m,
+    protocols::eth::{
+        ankr::AnkrApi, token_api::native::NativeTokenAPi, ChainId, RpcManagerI,
+    },
+    Error,
+};
+
+pub async fn fetch_token_balances(
+    rpc_manager: &dyn RpcManagerI,
+    tokens_for_address: m::EthTokensForAddress,
+) -> Result<Vec<TokenBalances>, Error> {
+    let m::EthTokensForAddress {
+        address,
+        fungible_tokens,
+        ..
+    } = tokens_for_address;
+
+    let fungible_tokens_by_api = fungible_tokens.into_iter().fold(
+        HashMap::new(),
+        |mut acc, (chain_id, contract_addresses)| {
+            let api = TokenApi::for_chain(chain_id);
+            acc.entry(api)
+                .or_insert_with(HashMap::new)
+                .insert(chain_id, contract_addresses);
+            acc
+        },
+    );
+
+    let results = futures::stream::iter(fungible_tokens_by_api.into_iter())
+        .map(|(api, fungible_tokens)| async move {
+            let result = match api {
+                TokenApi::Ankr => {
+                    let ankr = AnkrApi::new()?;
+                    ankr.fetch_token_balances(address).await?
+                }
+                TokenApi::Native => {
+                    let native = NativeTokenAPi::new(rpc_manager);
+                    native
+                        .fetch_token_balances(address, fungible_tokens)
+                        .await?
+                }
+            };
+            Ok::<_, Error>(result)
+        })
+        .buffered(TokenApi::iter().len())
+        .collect::<Vec<Result<Vec<_>, Error>>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<Vec<_>>, Error>>()?;
+
+    Ok(results.into_iter().flatten().collect())
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, strum_macros::EnumIter)]
+enum TokenApi {
+    Ankr,
+    Native,
+}
+
+impl TokenApi {
+    fn for_chain(chain_id: ChainId) -> Self {
+        match chain_id {
+            ChainId::EthMainnet => Self::Ankr,
+            ChainId::EthGoerli => Self::Ankr,
+            ChainId::PolygonMainnet => Self::Ankr,
+            ChainId::PolygonMumbai => Self::Ankr,
+        }
+    }
+}

--- a/core/src/protocols/eth/token_api/mod.rs
+++ b/core/src/protocols/eth/token_api/mod.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+mod native;
+mod token_balances;
+
+pub use token_balances::{FungibleTokenBalance, NFTBalance, TokenBalances};

--- a/core/src/protocols/eth/token_api/native.rs
+++ b/core/src/protocols/eth/token_api/native.rs
@@ -1,0 +1,471 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A token API that only uses standard Ethereum JSON-RPC methods to fetch token balances for
+//! maximum compatibility. Doesn't support NFTs yet. Doesn't support discovery.
+
+use std::{collections::HashMap, fmt::Debug, num::NonZeroUsize, sync::Arc};
+
+use ethers::{
+    abi::AbiDecode,
+    contract::FunctionCall,
+    prelude::{Provider, StreamExt, U256},
+    providers::Http,
+    types::{transaction::eip2718::TypedTransaction, Address},
+};
+use itertools::Itertools;
+use jsonrpsee::{
+    core::{
+        client::{CertificateStore, ClientT},
+        params::{ArrayParams, BatchRequestBuilder},
+        Error as JsonRpcError,
+    },
+    http_client::HttpClientBuilder,
+    rpc_params,
+};
+use lazy_static::lazy_static;
+use strum::IntoEnumIterator;
+use strum_macros::{EnumIter, EnumString};
+use url::Url;
+
+use crate::{
+    config,
+    protocols::eth::{
+        contracts::ERC20Contract, ChainId, ChecksumAddress, FungibleTokenBalance,
+        NativeTokenAmount, RpcManagerI, TokenBalances,
+    },
+    Error,
+};
+
+lazy_static! {
+    static ref MAX_BATCH_SIZE: NonZeroUsize = NonZeroUsize::new(1000).expect("static ok");
+}
+
+pub struct NativeTokenAPi<'a> {
+    max_batch_size: NonZeroUsize,
+    rpc_manager: &'a dyn RpcManagerI,
+}
+
+#[allow(dead_code)]
+impl<'a> NativeTokenAPi<'a> {
+    #[allow(dead_code)]
+    pub fn new(rpc_manager: &'a dyn RpcManagerI) -> Self {
+        Self::new_with_overrides(rpc_manager, *MAX_BATCH_SIZE)
+    }
+
+    fn new_with_overrides(
+        rpc_manager: &'a dyn RpcManagerI,
+        max_batch_size: NonZeroUsize,
+    ) -> Self {
+        Self {
+            rpc_manager,
+            max_batch_size,
+        }
+    }
+
+    /// Fetch token balances through standard Ethereum RPC calls.
+    /// Only supports native and ERC20 tokens currently.
+    /// `fungible_tokens` is a map from chain ID to ERC20 contract address.
+    pub async fn fetch_token_balances(
+        &'a self,
+        owner_address: ChecksumAddress,
+        fungible_tokens: HashMap<ChainId, Vec<ChecksumAddress>>,
+    ) -> Result<Vec<TokenBalances>, Error> {
+        let chain_ids = fungible_tokens.keys().copied();
+        let native_tokens = self.fetch_native_tokens(owner_address, chain_ids).await?;
+
+        let mut fungible_tokens = self
+            .fetch_fungible_tokens(owner_address, fungible_tokens)
+            .await;
+
+        native_tokens
+            .into_iter()
+            .map(|native_token| {
+                let chain_id = native_token.chain_id;
+                let fungible_tokens =
+                    fungible_tokens.remove(&chain_id).unwrap_or_default();
+                Ok(TokenBalances {
+                    chain_id,
+                    native_token,
+                    fungible_tokens,
+                    nfts: Default::default(),
+                })
+            })
+            .collect()
+    }
+
+    async fn fetch_native_tokens(
+        &'a self,
+        owner_address: ChecksumAddress,
+        chain_ids: impl IntoIterator<Item = ChainId>,
+    ) -> Result<Vec<NativeTokenAmount>, Error> {
+        let results: Vec<Result<NativeTokenAmount, Error>> =
+            futures::stream::iter(chain_ids)
+                .map(|chain_id| async move {
+                    let provider = self.rpc_manager.eth_api_provider(chain_id);
+                    let balance =
+                        provider.native_token_balance_async(owner_address).await?;
+                    Ok(balance)
+                })
+                .buffered(config::MAX_ASYNC_CONCURRENT_REQUESTS)
+                .collect()
+                .await;
+        results.into_iter().collect()
+    }
+
+    async fn fetch_fungible_tokens(
+        &'a self,
+        owner_address: ChecksumAddress,
+        fungible_tokens: HashMap<ChainId, Vec<ChecksumAddress>>,
+    ) -> HashMap<ChainId, Vec<FungibleTokenBalance>> {
+        futures::stream::iter(fungible_tokens.into_iter())
+            .filter_map(|(chain_id, contract_addresses)| async move {
+                let result = self.fetch_fungible_tokens_on_chain(
+                    owner_address,
+                    chain_id,
+                    contract_addresses,
+                )
+                    .await;
+                match result {
+                    // `buffered` needs futures but filter map returns values.
+                    Ok(result) => Some(async move { (chain_id, result) }),
+                    Err(err) => {
+                        log::error!("Error fetching fungible token balances for chain id {chain_id}: {err}");
+                        None
+                    },
+                }
+            })
+            .buffered(config::MAX_ASYNC_CONCURRENT_REQUESTS)
+            .collect()
+            .await
+    }
+
+    async fn fetch_fungible_tokens_on_chain(
+        &'a self,
+        owner_address: ChecksumAddress,
+        chain_id: ChainId,
+        fungible_token_addresses: Vec<ChecksumAddress>,
+    ) -> Result<Vec<FungibleTokenBalance>, Error> {
+        // TODO we don't actually use this so ideally we wouldn't have to create it, but the
+        // `ERC20Contract` needs it as argument. We als don't really need the `ERC20Contract`, only the
+        // call data, so this could be made a lot more efficient.
+        let rpc_endpoint = self.rpc_manager.http_endpoint(chain_id);
+        let provider = Arc::new(Provider::new(Http::new(rpc_endpoint.clone())));
+
+        let mut calls: Vec<EthCall> = Vec::with_capacity(
+            fungible_token_addresses.len() * FunctionName::iter().len(),
+        );
+        for contract_address in fungible_token_addresses {
+            let contract_address: Address = contract_address.into();
+            let contract = ERC20Contract::new(contract_address, provider.clone());
+            let contract_calls = calls_for_contract(contract, owner_address)?;
+            calls.extend(contract_calls);
+        }
+
+        let results = self.batch_eth_call(chain_id, calls).await?;
+
+        Ok(call_results_to_balances(chain_id, results))
+    }
+
+    async fn batch_eth_call(
+        &self,
+        chain_id: ChainId,
+        calls: Vec<EthCall>,
+    ) -> Result<Vec<EthCallResult>, JsonRpcError> {
+        let client = HttpClientBuilder::default()
+            .certificate_store(CertificateStore::WebPki)
+            .build(self.rpc_manager.http_endpoint(chain_id))?;
+
+        let mut results: Vec<EthCallResult> = Vec::with_capacity(calls.len());
+
+        for chunk in calls
+            .into_iter()
+            .chunks(self.max_batch_size.into())
+            .into_iter()
+        {
+            let chunk: Vec<EthCall> = chunk.collect();
+            let mut batch = BatchRequestBuilder::new();
+            chunk
+                .iter()
+                .try_for_each(|call| batch.insert(call.method, call.rpc_params()))?;
+            let responses = client.batch_request::<'_, '_, '_, String>(batch).await?;
+            responses.into_iter().zip(chunk).for_each(|(response, call)| {
+                match response {
+                    Ok(result) => {
+                        results.push(EthCallResult {
+                            call,
+                            result,
+                        })
+                    },
+                    Err(err) => {
+                        log::error!("Error fetching fungible token balance for chain {chain_id}: '{} {}'", err.code(), err.message());
+                    },
+                }
+            });
+        }
+
+        Ok(results)
+    }
+}
+
+#[derive(Clone, Debug, EnumString, EnumIter, strum_macros::Display)]
+#[strum(serialize_all = "camelCase")]
+pub enum FunctionName {
+    BalanceOf,
+    Decimals,
+    Symbol,
+}
+
+#[derive(Debug)]
+struct EthCall {
+    method: &'static str,
+    function: FunctionName,
+    address: ChecksumAddress,
+    tx: TypedTransaction,
+}
+
+impl EthCall {
+    fn new(function_name: &str, tx: TypedTransaction) -> Result<Self, Error> {
+        let function: FunctionName = function_name.parse().map_err(|_| Error::Fatal {
+            // Logic error
+            error: "Invalid function name".into(),
+        })?;
+        let address: ChecksumAddress = tx
+            .to_addr()
+            .copied()
+            .ok_or(Error::Fatal {
+                // Logic error
+                error: "Transaction doesn't have to address".into(),
+            })?
+            .into();
+        Ok(EthCall {
+            method: "eth_call",
+            function,
+            address,
+            tx,
+        })
+    }
+
+    fn rpc_params(&self) -> ArrayParams {
+        rpc_params![&self.tx, "latest"]
+    }
+}
+
+#[derive(Debug)]
+struct EthCallResult {
+    call: EthCall,
+    result: String,
+}
+
+fn calls_for_contract(
+    contract: ERC20Contract<Provider<Http>>,
+    owner_address: ChecksumAddress,
+) -> Result<[EthCall; 3], Error> {
+    Ok([
+        call_to_request(contract.balance_of(owner_address.into()))?,
+        call_to_request(contract.symbol())?,
+        call_to_request(contract.decimals())?,
+    ])
+}
+
+fn call_to_request<B, M, D>(call: FunctionCall<B, M, D>) -> Result<EthCall, Error> {
+    EthCall::new(&call.function.name, call.tx)
+}
+
+/// Convert `eth_call` results to `FungibleTokenBalance` objects.
+fn call_results_to_balances(
+    chain_id: ChainId,
+    results: Vec<EthCallResult>,
+) -> Vec<FungibleTokenBalance> {
+    let by_contract =
+        results
+            .into_iter()
+            .fold(HashMap::new(), |mut by_contract, call_result| {
+                by_contract
+                    .entry(call_result.call.address)
+                    .or_insert_with(Vec::new)
+                    .push(call_result);
+                by_contract
+            });
+
+    by_contract
+        .into_iter()
+        .filter_map(|(contract_address, call_result)| {
+            call_result_to_balance(chain_id, contract_address, call_result)
+        })
+        .collect()
+}
+
+fn call_result_to_balance(
+    chain_id: ChainId,
+    contract_address: ChecksumAddress,
+    call_result: Vec<EthCallResult>,
+) -> Option<FungibleTokenBalance> {
+    let mut balance = None;
+    let mut decimals = None;
+    let mut symbol = None;
+    for result in call_result {
+        match result.call.function {
+            FunctionName::BalanceOf => balance = Some(result.result),
+            FunctionName::Decimals => decimals = Some(result.result),
+            FunctionName::Symbol => symbol = Some(result.result),
+        }
+    }
+    let balance = balance?;
+    let decimals = decimals?;
+    let symbol = symbol?;
+
+    let decimals = u8::decode_hex(decimals).map_or_else(
+        |err| {
+            log::error!("Failed to parse decimals: {}", err);
+            None
+        },
+        Some,
+    )?;
+    let balance = U256::decode_hex(balance).map_or_else(
+        |err| {
+            log::error!("Failed to parse balance: {}", err);
+            None
+        },
+        Some,
+    )?;
+    let symbol = String::decode_hex(symbol).map_or_else(
+        |err| {
+            log::error!("Failed to parse symbol: {}", err);
+            None
+        },
+        Some,
+    )?;
+
+    Some(FungibleTokenBalance {
+        chain_id,
+        contract_address,
+        amount: balance,
+        decimals,
+        symbol,
+        logo: logo_url(chain_id, &contract_address),
+    })
+}
+
+/// Fetch the logo url for a given token from Trust Wallet Assets.
+/// Not guaranteed that the logo at the url exists. Have to query it to make sure.
+fn logo_url(chain_id: ChainId, contract_address: &ChecksumAddress) -> Option<Url> {
+    chain_id_to_logo_name(chain_id).and_then(|chain_name| {
+        let url = format!(
+            "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/{}/assets/{}/logo.png",
+            chain_name,
+            contract_address
+        );
+        Url::parse(&url).map_or_else(
+            |err| {
+                log::error!("Failed to parse logo url: {}", err);
+                None
+            },
+            Some,
+        )
+    })
+}
+
+fn chain_id_to_logo_name(chain_id: ChainId) -> Option<&'static str> {
+    match chain_id {
+        ChainId::EthMainnet => Some("ethereum"),
+        ChainId::EthGoerli => None,
+        ChainId::PolygonMainnet => Some("polygon"),
+        ChainId::PolygonMumbai => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::*;
+    use crate::{
+        async_runtime as rt, protocols::eth::contracts::test_util::TestContractDeployer,
+    };
+
+    #[test]
+    fn test_logo_url_ethereum() {
+        let expected: Url = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png".parse().unwrap();
+        let actual = logo_url(
+            ChainId::EthMainnet,
+            &"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_logo_url_polygon() {
+        let expected: Url = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png".parse().unwrap();
+        let actual = logo_url(
+            ChainId::PolygonMainnet,
+            &"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_token_balances() -> Result<()> {
+        // One token needs 3 calls, so batch size of 2 lets us simulate paging.
+        let max_batch_size = NonZeroUsize::new(2).unwrap();
+        let chain_id = ChainId::EthMainnet;
+
+        let contract_deployer = TestContractDeployer::init(chain_id);
+        let contract_address = contract_deployer.deploy_fungible_token_test_contract()?;
+        let _rpc_provider = contract_deployer.anvil_rpc.eth_api_provider(chain_id);
+        let provider = Arc::new(contract_deployer.provider());
+        let contract = ERC20Contract::new(contract_address, provider);
+        let symbol = rt::block_on(contract.symbol().call())?;
+        assert!(!symbol.is_empty());
+        let decimals = rt::block_on(contract.decimals().call())?;
+        assert!(decimals > 0);
+        let balance = rt::block_on(
+            contract
+                .balance_of(contract_deployer.deployer_address().into())
+                .call(),
+        )?;
+        assert!(!balance.is_zero());
+
+        let token_api = NativeTokenAPi::new_with_overrides(
+            &contract_deployer.anvil_rpc,
+            max_batch_size,
+        );
+
+        // Two contracts: one that exists and that doesn't to simulate errors.
+        let fungible_tokens: HashMap<ChainId, Vec<ChecksumAddress>> =
+            vec![(chain_id, vec![Address::random().into(), contract_address])]
+                .into_iter()
+                .collect();
+        let token_balances = rt::block_on(token_api.fetch_token_balances(
+            contract_deployer.deployer_address(),
+            fungible_tokens,
+        ))?;
+
+        assert_eq!(token_balances.len(), 1);
+        let balances = token_balances.into_iter().next().unwrap();
+
+        assert_eq!(balances.chain_id, chain_id);
+        assert!(!balances.native_token.amount.is_zero());
+
+        assert_eq!(balances.fungible_tokens.len(), 1);
+        assert_eq!(balances.fungible_tokens[0].chain_id, chain_id);
+        assert_eq!(
+            balances.fungible_tokens[0].contract_address,
+            contract_address
+        );
+        assert_eq!(balances.fungible_tokens[0].symbol, symbol);
+        assert_eq!(balances.fungible_tokens[0].decimals, decimals);
+        assert_eq!(balances.fungible_tokens[0].amount, balance);
+        // There is only a logo, bc we specified Ethereum mainnet as the chain id.
+        assert!(balances.fungible_tokens[0].logo.is_some());
+
+        Ok(())
+    }
+}

--- a/core/src/protocols/eth/token_api/native.rs
+++ b/core/src/protocols/eth/token_api/native.rs
@@ -10,10 +10,10 @@ use std::{collections::HashMap, fmt::Debug, num::NonZeroUsize, sync::Arc};
 use ethers::{
     abi::AbiDecode,
     contract::FunctionCall,
-    prelude::{Provider, StreamExt, U256},
-    providers::Http,
-    types::{transaction::eip2718::TypedTransaction, Address},
+    providers::{Http, Provider},
+    types::{transaction::eip2718::TypedTransaction, Address, U256},
 };
+use futures::StreamExt;
 use itertools::Itertools;
 use jsonrpsee::{
     core::{
@@ -67,7 +67,7 @@ impl<'a> NativeTokenAPi<'a> {
     /// Fetch token balances through standard Ethereum RPC calls.
     /// Only supports native and ERC20 tokens currently.
     /// `fungible_tokens` is a map from chain ID to ERC20 contract address.
-    pub async fn fetch_token_balances(
+    pub(super) async fn fetch_token_balances(
         &'a self,
         owner_address: ChecksumAddress,
         fungible_tokens: HashMap<ChainId, Vec<ChecksumAddress>>,

--- a/core/src/protocols/eth/token_api/token_balances.rs
+++ b/core/src/protocols/eth/token_api/token_balances.rs
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::fmt::Debug;
+
 use ethers::prelude::U256;
+use url::Url;
 
 use crate::protocols::eth::{token, ChainId, ChecksumAddress, NativeTokenAmount};
 
@@ -13,8 +16,7 @@ pub struct FungibleTokenBalance {
     pub amount: U256,
     pub decimals: u8,
     pub symbol: String,
-    pub name: String,
-    pub logo: Option<url::Url>,
+    pub logo: Option<Url>,
 }
 
 impl FungibleTokenBalance {
@@ -31,7 +33,7 @@ pub struct NFTBalance {
     pub collection_name: String,
     pub name: String,
     pub token_id: String,
-    pub image_url: Option<url::Url>,
+    pub image_url: Option<Url>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/core/src/protocols/eth/token_balances.rs
+++ b/core/src/protocols/eth/token_balances.rs
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ethers::prelude::U256;
+
+use crate::protocols::eth::{token, ChainId, ChecksumAddress, NativeTokenAmount};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FungibleTokenBalance {
+    pub chain_id: ChainId,
+    pub contract_address: ChecksumAddress,
+    pub amount: U256,
+    pub decimals: u8,
+    pub symbol: String,
+    pub name: String,
+    pub logo: Option<url::Url>,
+}
+
+impl FungibleTokenBalance {
+    pub fn display_amount(&self) -> String {
+        token::display_amount(self.amount, self.decimals)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NFTBalance {
+    pub chain_id: ChainId,
+    pub contract_address: ChecksumAddress,
+    pub symbol: String,
+    pub collection_name: String,
+    pub name: String,
+    pub token_id: String,
+    pub image_url: Option<url::Url>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct TokenBalances {
+    pub chain_id: ChainId,
+    pub native_token: NativeTokenAmount,
+    pub fungible_tokens: Vec<FungibleTokenBalance>,
+    pub nfts: Vec<NFTBalance>,
+}
+
+impl TokenBalances {
+    pub fn default_for_chain(chain_id: ChainId) -> Self {
+        TokenBalances {
+            chain_id,
+            native_token: NativeTokenAmount::zero_balance(chain_id),
+            fungible_tokens: Vec::new(),
+            nfts: Vec::new(),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for fetching fungible token balances through standard Ethereum RPC methods. This is required to support new chains in SealVault that aren't supported by the [Ankr Advanced Token API.](https://www.ankr.com/docs/advanced-api/overview/)

Limitations:
- No token discovery support
- Only supports native and fungible tokens, no NFT support